### PR TITLE
Makefile improvemnts, use keyboard in some apps

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -1,0 +1,40 @@
+
+Use the following shell variables to influence the build:
+
+DEBUG=1
+    To build the apps with debug symbols, 0-optimization and asserts.
+
+LVGL_USE_SDL=[1|y|Y]
+    To build the apps for PC, using SDL2 emulation of screen and input devices.
+
+LVGL_BUILD_TUTORIAL=0     [default if not given]
+    To build the demo app in lv_examples/lv_apps/demo/.
+    This is the default if this var is not set.
+
+LVGL_BUILD_TUTORIAL=1
+    To build the 10_keyboard tutorial app in lv_examples/lv_tutorial.
+    You may also look at the lv_tutorial_keyboard.mk file and choose
+    between simulated keypad or real keyboard inside of it.
+
+LVGL_MINIMAL_BUILD=0      [default if not given]
+    By default the build infrastructure links the app with all object files.
+    This setting leaves this as-is.
+
+LVGL_MINIMAL_BUILD=1
+    By default the build infrastructure links the app with all object files.
+    This setting selects only the necessary object files for linking,
+    reducing considerably the size of the apps.
+    NOTE: This is not yet fully implemented
+
+
+Examples:
+---------
+To build the 'demo' app on PC with full debug info:
+$  DEBUG=1 LVGL_USE_SDL=1 make
+   -OR-
+$  DEBUG=1 LVGL_USE_SDL=1 LVGL_BUILD_TUTORIAL=0 make
+
+To build the '10_keyboard' tutorial app for your architecture, with no debug infos:
+$ LVGL_BUILD_TUTORIAL=1 make
+NOTE: This will usually require specifying other options, depending on your target architecture.
+

--- a/main.c
+++ b/main.c
@@ -7,15 +7,37 @@
 /*********************
  *      INCLUDES
  *********************/
+/* INCLUDE THIS FILE FIRST! IT SETS UP DEFINES AND SYSTEM SETTINGS */
+#include "lv_drv_conf.h"
+
+#include <assert.h>
+#include <features.h>
+#include <stdio.h>
 #include <stdlib.h>
+
+#if defined _POSIX_SOURCE
 #include <unistd.h>
+#endif      /*_POSIX_SOURCE*/
+
 #include <SDL2/SDL.h>
+
 #include "lvgl/lvgl.h"
 #include "lv_drivers/display/monitor.h"
 #include "lv_drivers/indev/mouse.h"
+#if USE_KEYBOARD
+#include "lv_drivers/indev/keyboard.h"
+#endif
+
+#if BUILD_DEMO
 #include "lv_examples/lv_apps/demo/demo.h"
+#elif BUILD_TUTORIAL
+#include "lv_examples/lv_tutorial/10_keyboard/lv_tutorial_keyboard.h"
+#else
+/* TODO: Provide other switches to control these demo builds
 #include "lv_examples/lv_apps/benchmark/benchmark.h"
 #include "lv_examples/lv_tests/lv_test_theme/lv_test_theme.h"
+*/
+#endif
 
 /*********************
  *      DEFINES
@@ -40,6 +62,13 @@ static int tick_thread(void *data);
  **********************/
 
 /**********************
+ *   GLOBAL VARIABLES
+ **********************/
+#if USE_KEYBOARD
+lv_indev_t * g_kbd_dev = NULL;
+#endif
+
+/**********************
  *   GLOBAL FUNCTIONS
  **********************/
 
@@ -51,9 +80,13 @@ int main(int argc, char** argv)
     /*Initialize the HAL for LittlevGL*/
     hal_init();
 
+#if BUILD_DEMO
     /*Load a demo*/
-    demo_create();
-
+    demo_create(g_kbd_dev);
+#elif BUILD_TUTORIAL
+    /*Load keyboard tutorial code*/
+    lv_tutorial_keyboard(g_kbd_dev);
+#endif
     /*Or try the benchmark too to see the speed of your MCU*/
     //benchmark_create();
 
@@ -89,6 +122,16 @@ static void hal_init(void)
     disp_drv.disp_fill = monitor_fill;
     disp_drv.disp_map = monitor_map;
     lv_disp_drv_register(&disp_drv);
+
+#if USE_KEYBOARD
+    /* Use the 'keyboard' driver which reads the PC's keyboard*/
+    keyboard_init();
+    lv_indev_drv_t kbd_drv;
+    lv_indev_drv_init(&kbd_drv);          /*Basic initialization*/
+    kbd_drv.type = LV_INDEV_TYPE_KEYPAD;
+    kbd_drv.read = keyboard_read;         /*This function will be called periodically (by the library) to read the keyboard*/
+    g_kbd_dev = lv_indev_drv_register(&kbd_drv);
+#endif
 
     /* Add the mouse (or touchpad) as input device
      * Use the 'mouse' driver which reads the PC's mouse*/


### PR DESCRIPTION
1. Improvements to Makefile and the build process:
     - Allowing external CC to be passed to the make file to allo cross-builds
     - Adding comment about race condition during make due to 'clean' removing .o files
     - Adding 'maintainer-clean' target
     - Adding 'help' target and a help file to be displayed on 'make help'
     - Adding several LVGL_... vars to control build targets and settings
     - Adding DEBUG var to allow debug/release builds

2. Allowing the demo and keyboard_tutorial apps to use the (real) keyboard.